### PR TITLE
Stencil use ref instead of query selector

### DIFF
--- a/packages/better-img-stencil/src/components/better-img-stencil/better-img-stencil.tsx
+++ b/packages/better-img-stencil/src/components/better-img-stencil/better-img-stencil.tsx
@@ -15,10 +15,13 @@ export class BetterImgStencil {
   @Prop() width: number = 480;
 
   @State() usingFallback: boolean = false;
+  
+  image: HTMLImageElement;
 
   render() {
     return (
       <img
+        ref={(img: HTMLImageElement) => this.image = img}
         onError={this.handleImgError.bind(this)}
         width={this.width}
         height={this.height}
@@ -29,10 +32,6 @@ export class BetterImgStencil {
 
   componentDidLoad() {
     this.setSrc(this.url);
-  }
-
-  get image() {
-    return this.el.querySelector("img");
   }
 
   handleImgError(error) {


### PR DESCRIPTION
This is a handy Stencil trick I learned from here: https://github.com/ionic-team/stencil/issues/597, now a reference to the img is stored and you wont have to query select every time you want to access it 😄 