### PR TITLE
Run lerna bootstrap with  --no-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "lerna:publish": "lerna publish",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap  --no-ci",
     "test": "lerna run test"
   },
   "devDependencies": {


### PR DESCRIPTION
CI is failing because there isn't a `package-lock.json` which `npm ci` requires. This tells lerna to use `npm install` instead. If `package-lock.json` was added for all packages, `--no-ci` should be removed for performance.